### PR TITLE
Revert "Service paths for Lagom are required to be preserved"

### DIFF
--- a/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala
@@ -195,7 +195,7 @@ object LagomBundle extends AutoPlugin {
       case name if name.startsWith("/") => name.drop(1) // TODO: The drop will not be necessary anymore once Lagom verifies the service name
       case name => name
     }
-    formattedServiceNames.map(name => name -> Endpoint("http", 0, Set(URI(s"http://:$servicePort/$name?preservePath")))).toMap
+    formattedServiceNames.map(name => name -> Endpoint("http", 0, Set(URI(s"http://:$servicePort/$name")))).toMap
   }
 
   private def envName(name: String) =

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/build.sbt
@@ -31,7 +31,7 @@ checkBundleConf := {
                                  |  "payment" = {
                                  |    bind-protocol = "http"
                                  |    bind-port     = 0
-                                 |    services      = ["http://:9000/payment?preservePath"]
+                                 |    services      = ["http://:9000/payment"]
                                  |  },
                                  |  "akka-remote" = {
                                  |    bind-protocol = "tcp"
@@ -46,7 +46,7 @@ checkBundleConf := {
                                 |  "payment" = {
                                 |    bind-protocol = "http"
                                 |    bind-port     = 0
-                                |    services      = ["http://:9000/payment?preservePath"]
+                                |    services      = ["http://:9000/payment"]
                                 |  },
                                 |  "akka-remote" = {
                                 |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/build.sbt
@@ -31,7 +31,7 @@ checkBundleConf := {
                                    |  "frontend" = {
                                    |    bind-protocol = "http"
                                    |    bind-port     = 0
-                                   |    services      = ["http://:9000/frontend?preservePath"]
+                                   |    services      = ["http://:9000/frontend"]
                                    |  },
                                    |  "akka-remote" = {
                                    |    bind-protocol = "tcp"
@@ -47,7 +47,7 @@ checkBundleConf := {
                                   |  "backend" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/backend?preservePath"]
+                                  |    services      = ["http://:9000/backend"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects/build.sbt
@@ -31,12 +31,12 @@ checkBundleConf := {
                                   |  "debit" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/debit?preservePath"]
+                                  |    services      = ["http://:9000/debit"]
                                   |  },
                                   |  "credit" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/credit?preservePath"]
+                                  |    services      = ["http://:9000/credit"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"
@@ -51,7 +51,7 @@ checkBundleConf := {
                                  |  "social/feed" = {
                                  |    bind-protocol = "http"
                                  |    bind-port     = 0
-                                 |    services      = ["http://:9000/social/feed?preservePath"]
+                                 |    services      = ["http://:9000/social/feed"]
                                  |  },
                                  |  "akka-remote" = {
                                  |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/build.sbt
@@ -24,7 +24,7 @@ checkBundleConf := {
                                   |  "payment" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/payment?preservePath"]
+                                  |    services      = ["http://:9000/payment"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/build.sbt
@@ -24,12 +24,12 @@ checkBundleConf := {
                            |  "fooservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/fooservice?preservePath"]
+                           |    services      = ["http://:9000/fooservice"]
                            |  },
                            |  "barservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/barservice?preservePath"]
+                           |    services      = ["http://:9000/barservice"]
                            |  },
                            |  "akka-remote" = {
                            |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/simple/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/simple/build.sbt
@@ -23,7 +23,7 @@ checkBundleConf := {
                            |  "fooservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/fooservice?preservePath"]
+                           |    services      = ["http://:9000/fooservice"]
                            |  },
                            |  "akka-remote" = {
                            |    bind-protocol = "tcp"


### PR DESCRIPTION
This reverts commit 61eb8c548c1a1dd2df4a0644dfe6fce85a8b0148.

The reason I'm reverting is that the first path component is always the name of the service when generating service uris here. That name has nothing to do with the path generated by Lagom, and so leveraging ConductR to strip it is fine.

As an example:

```scala
    return named("friendservice").with(
        restCall(Method.POST, "/api/users", createUser())
      ).withAutoAcl(true);
```

...the service only expects /api/users, not /friendservice/api/users.

I actually confirmed this behaviour within the sandbox.