### PR TITLE
Add ACL paths for proxying

### DIFF
--- a/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala
@@ -68,7 +68,7 @@ object LagomBundle extends AutoPlugin {
             )).toSeq.flatten
           // The application secret is not used by the Lagom project so the value doesn't really matter.
           // Therefore it is save to automatically generate one here. It is necessary though to set the key in prod mode.
-          val applicationSecret = s"-Dplay.crypto.secret=${SbtBundle.hash(s"${name.value}-${version}")}"
+          val applicationSecret = s"-Dplay.crypto.secret=${SbtBundle.hash(s"${name.value}-$version")}"
           bindings :+ applicationSecret
         }
       )
@@ -126,7 +126,7 @@ object LagomBundle extends AutoPlugin {
   private def copyDirectoryFromJar(fromJarFile: JarFile, targetDir: File, dirPrefix: String): Unit = {
     fromJarFile.entries.asScala.foreach { entry =>
       if(entry.getName.startsWith(dirPrefix) && !entry.isDirectory) {
-        val name = entry.getName.drop(dirPrefix.size)
+        val name = entry.getName.drop(dirPrefix.length)
         val toFile = targetDir / name
         withJarInputStream(fromJarFile, entry) { in =>
           IO.transfer(in, toFile)
@@ -185,17 +185,45 @@ object LagomBundle extends AutoPlugin {
   private def toClasspathUrls(attributedFiles: Seq[Attributed[File]]): Array[URL] =
     attributedFiles.files.map(_.toURI.toURL).toArray
 
+  private val pathBeginExtractor = """^\\Q(/.*)\\E.*""".r
+
   /**
     * Convert services string to `Map[String, Endpoint]` by using the Play json library
     */
   private def toConductrEndpoints(services: String, servicePort: Int): Map[String, Endpoint] = {
     val json = Json.parse(services)
-    val serviceNames = (json \\ "name").flatMap(_.asOpt[String])
-    val formattedServiceNames = serviceNames.map {
-      case name if name.startsWith("/") => name.drop(1) // TODO: The drop will not be necessary anymore once Lagom verifies the service name
-      case name => name
+    val serviceNamesAndPaths = json.as[List[JsObject]].map { o =>
+      val serviceName = (o \ "name").as[String]
+      val pathlessServiceName = if (serviceName.startsWith("/")) serviceName.drop(1) else serviceName
+      val pathBegins = (o \ "acls" \\ "pathPattern")
+        .map(_.as[String])
+        .collect {
+          case pathBeginExtractor(pathBegin) =>
+            (if (pathBegin.endsWith("/")) pathBegin.dropRight(1) else pathBegin) + "?preservePath"
+        }
+      pathlessServiceName -> pathBegins
     }
-    formattedServiceNames.map(name => name -> Endpoint("http", 0, Set(URI(s"http://:$servicePort/$name")))).toMap
+    serviceNamesAndPaths
+      .map {
+        case (serviceName, pathBegins) =>
+          val uris = pathBegins.map(p => URI(s"http://:$servicePort$p")).toSet
+          serviceName -> Endpoint("http", services = uris)
+      }
+      .foldLeft(Map.empty[String, Endpoint]) {
+        case (prev, (serviceName, endpoint)) =>
+          val mergedEndpoint =
+            prev.get(serviceName)
+              .fold(endpoint) { prevEndpoint =>
+                val mergedServices = (prevEndpoint.services, endpoint.services) match {
+                  case (Some(prevServices), Some(newServices)) => Some(prevServices ++ newServices)
+                  case (Some(prevServices), None)              => Some(prevServices)
+                  case (None              , Some(newServices)) => Some(newServices)
+                  case (None              , None)              => None
+                }
+                prevEndpoint.copy(services = mergedServices)
+              }
+          prev + (serviceName -> mergedEndpoint)
+      }
   }
 
   private def envName(name: String) =
@@ -221,7 +249,7 @@ private object ServiceDetector {
   def services(classLoader: ClassLoader): String =
     withContextClassloader(classLoader) { loader =>
       getSingletonObject[ServiceDetector](loader, "com.lightbend.lagom.internal.api.tools.ServiceDetector$") match {
-        case Failure(t) => fail(s"Endpoints can not be resolved from Lagom project. Error: ${t.getMessage}")
+        case Failure(t)               => fail(s"Endpoints can not be resolved from Lagom project. Error: ${t.getMessage}")
         case Success(serviceDetector) => serviceDetector.services(loader)
       }
     }
@@ -230,7 +258,7 @@ private object ServiceDetector {
     * Uses the given class loader for the given code block
     */
   private def withContextClassloader[T](loader: ClassLoader)(body: ClassLoader => T): T = {
-    val current = Thread.currentThread().getContextClassLoader()
+    val current = Thread.currentThread().getContextClassLoader
     try {
       Thread.currentThread().setContextClassLoader(loader)
       body(loader)

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/build.sbt
@@ -26,12 +26,12 @@ checkBundleConf := {
     def indent: String = s.replaceAll("  ", "")
   }
 
-  val creditContent = IO.read((target in debitImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
+  val creditContent = IO.read((target in creditImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedCreditContent = """|endpoints = {
                                  |  "payment" = {
                                  |    bind-protocol = "http"
                                  |    bind-port     = 0
-                                 |    services      = ["http://:9000/payment"]
+                                 |    services      = ["http://:9000/credit?preservePath"]
                                  |  },
                                  |  "akka-remote" = {
                                  |    bind-protocol = "tcp"
@@ -41,12 +41,12 @@ checkBundleConf := {
                                  |}""".stripMargin.indent
   creditContent should include (expectedCreditContent)
 
-  val debitContent = IO.read((target in creditImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
+  val debitContent = IO.read((target in debitImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedDebitContent = """|endpoints = {
                                 |  "payment" = {
                                 |    bind-protocol = "http"
                                 |    bind-port     = 0
-                                |    services      = ["http://:9000/payment"]
+                                |    services      = ["http://:9000/debit?preservePath"]
                                 |  },
                                 |  "akka-remote" = {
                                 |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/build.sbt
@@ -31,7 +31,7 @@ checkBundleConf := {
                                    |  "frontend" = {
                                    |    bind-protocol = "http"
                                    |    bind-port     = 0
-                                   |    services      = ["http://:9000/frontend"]
+                                   |    services      = ["http://:9000/foo?preservePath"]
                                    |  },
                                    |  "akka-remote" = {
                                    |    bind-protocol = "tcp"
@@ -47,7 +47,7 @@ checkBundleConf := {
                                   |  "backend" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/backend"]
+                                  |    services      = []
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects/build.sbt
@@ -31,12 +31,12 @@ checkBundleConf := {
                                   |  "debit" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/debit"]
+                                  |    services      = ["http://:9000?preservePath"]
                                   |  },
                                   |  "credit" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/credit"]
+                                  |    services      = ["http://:9000?preservePath"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"
@@ -51,7 +51,7 @@ checkBundleConf := {
                                  |  "social/feed" = {
                                  |    bind-protocol = "http"
                                  |    bind-port     = 0
-                                 |    services      = ["http://:9000/social/feed"]
+                                 |    services      = ["http://:9000?preservePath"]
                                  |  },
                                  |  "akka-remote" = {
                                  |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/build.sbt
@@ -20,11 +20,11 @@ checkBundleConf := {
   }
 
   val paymentContent = IO.read((target in paymentImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
-  val expectedPaymentContent = """|endpoints = {
+  val expectedPaymentContent1 = """|endpoints = {
                                   |  "payment" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/payment"]
+                                  |    services      = ["http://:9000/debit?preservePath", "http://:9000/credit?preservePath"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"
@@ -32,5 +32,17 @@ checkBundleConf := {
                                   |    services= []
                                   |  }
                                   |}""".stripMargin.indent
-  paymentContent should include (expectedPaymentContent)
+  val expectedPaymentContent2 = """|endpoints = {
+                                  |  "payment" = {
+                                  |    bind-protocol = "http"
+                                  |    bind-port     = 0
+                                  |    services      = ["http://:9000/credit?preservePath", "http://:9000/debit?preservePath"]
+                                  |  },
+                                  |  "akka-remote" = {
+                                  |    bind-protocol = "tcp"
+                                  |    bind-port = 0
+                                  |    services= []
+                                  |  }
+                                  |}""".stripMargin.indent
+  paymentContent should (include (expectedPaymentContent1) or include (expectedPaymentContent2))
 }

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/build.sbt
@@ -24,12 +24,12 @@ checkBundleConf := {
                            |  "fooservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/fooservice"]
+                           |    services      = ["http://:9000/foo?preservePath"]
                            |  },
                            |  "barservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/barservice"]
+                           |    services      = ["http://:9000/bar?preservePath"]
                            |  },
                            |  "akka-remote" = {
                            |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/simple/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/simple/build.sbt
@@ -23,7 +23,7 @@ checkBundleConf := {
                            |  "fooservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/fooservice"]
+                           |    services      = ["http://:9000/foo?preservePath"]
                            |  },
                            |  "akka-remote" = {
                            |    bind-protocol = "tcp"


### PR DESCRIPTION
Given our service URIs, we must also expose the ACL paths so that the services may be reached from the outside world. The ACL paths must have their paths preserved.

The main shortcoming of this approach compared with our forthcoming ACL implementation of ConductR 1.2 is that we do not test the HTTP method.

Sample output for the chirper-impl:

```
> show bundleOverrideEndpoints

[info] Some(Map(chirpservice -> Endpoint(http,0,Some(Set(http://:9000/chirpservice, 
http://:9000/api/chirps/live?preservePath, http://:9000/api/chirps/history?preservePath)),None,None), 
akka-remote -> Endpoint(tcp,0,Some(Set()),None,None)))
```