### PR TITLE
Add ACL paths for proxying

### DIFF
--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/build.sbt
@@ -26,12 +26,12 @@ checkBundleConf := {
     def indent: String = s.replaceAll("  ", "")
   }
 
-  val creditContent = IO.read((target in debitImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
+  val creditContent = IO.read((target in creditImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedCreditContent = """|endpoints = {
                                  |  "payment" = {
                                  |    bind-protocol = "http"
                                  |    bind-port     = 0
-                                 |    services      = ["http://:9000/payment"]
+                                 |    services      = ["http://:9000/credit?preservePath"]
                                  |  },
                                  |  "akka-remote" = {
                                  |    bind-protocol = "tcp"
@@ -41,12 +41,12 @@ checkBundleConf := {
                                  |}""".stripMargin.indent
   creditContent should include (expectedCreditContent)
 
-  val debitContent = IO.read((target in creditImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
+  val debitContent = IO.read((target in debitImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedDebitContent = """|endpoints = {
                                 |  "payment" = {
                                 |    bind-protocol = "http"
                                 |    bind-port     = 0
-                                |    services      = ["http://:9000/payment"]
+                                |    services      = ["http://:9000/debit?preservePath"]
                                 |  },
                                 |  "akka-remote" = {
                                 |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/build.sbt
@@ -31,7 +31,7 @@ checkBundleConf := {
                                    |  "frontend" = {
                                    |    bind-protocol = "http"
                                    |    bind-port     = 0
-                                   |    services      = ["http://:9000/frontend"]
+                                   |    services      = ["http://:9000/foo?preservePath"]
                                    |  },
                                    |  "akka-remote" = {
                                    |    bind-protocol = "tcp"
@@ -47,7 +47,7 @@ checkBundleConf := {
                                   |  "backend" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/backend"]
+                                  |    services      = []
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects/build.sbt
@@ -31,12 +31,12 @@ checkBundleConf := {
                                   |  "debit" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/debit"]
+                                  |    services      = ["http://:9000?preservePath"]
                                   |  },
                                   |  "credit" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/credit"]
+                                  |    services      = ["http://:9000?preservePath"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"
@@ -51,7 +51,7 @@ checkBundleConf := {
                                  |  "social/feed" = {
                                  |    bind-protocol = "http"
                                  |    bind-port     = 0
-                                 |    services      = ["http://:9000/social/feed"]
+                                 |    services      = ["http://:9000?preservePath"]
                                  |  },
                                  |  "akka-remote" = {
                                  |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/build.sbt
@@ -20,11 +20,11 @@ checkBundleConf := {
   }
 
   val paymentContent = IO.read((target in paymentImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
-  val expectedPaymentContent = """|endpoints = {
+  val expectedPaymentContent1 = """|endpoints = {
                                   |  "payment" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/payment"]
+                                  |    services      = ["http://:9000/debit?preservePath", "http://:9000/credit?preservePath"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"
@@ -32,5 +32,17 @@ checkBundleConf := {
                                   |    services= []
                                   |  }
                                   |}""".stripMargin.indent
-  paymentContent should include (expectedPaymentContent)
+  val expectedPaymentContent2 = """|endpoints = {
+                                  |  "payment" = {
+                                  |    bind-protocol = "http"
+                                  |    bind-port     = 0
+                                  |    services      = ["http://:9000/credit?preservePath", "http://:9000/debit?preservePath"]
+                                  |  },
+                                  |  "akka-remote" = {
+                                  |    bind-protocol = "tcp"
+                                  |    bind-port = 0
+                                  |    services= []
+                                  |  }
+                                  |}""".stripMargin.indent
+  paymentContent should (include (expectedPaymentContent1) or include (expectedPaymentContent2))
 }

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/build.sbt
@@ -24,12 +24,12 @@ checkBundleConf := {
                            |  "fooservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/fooservice"]
+                           |    services      = ["http://:9000/foo?preservePath"]
                            |  },
                            |  "barservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/barservice"]
+                           |    services      = ["http://:9000/bar?preservePath"]
                            |  },
                            |  "akka-remote" = {
                            |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/simple/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/simple/build.sbt
@@ -23,7 +23,7 @@ checkBundleConf := {
                            |  "fooservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/fooservice"]
+                           |    services      = ["http://:9000/foo?preservePath"]
                            |  },
                            |  "akka-remote" = {
                            |    bind-protocol = "tcp"


### PR DESCRIPTION
This PR continues the work in PR https://github.com/typesafehub/sbt-lagom-bundle/pull/9. In particular it rebased the PR and made the this method a bit more readable: https://github.com/huntc/sbt-lagom-bundle/blob/f66c5f570331af6db9f3aa8955119fbeff9a503e/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala#L193

**Original description**

Given our service URIs, we must also expose the ACL paths so that the services may be reached from the outside world. The ACL paths must have their paths preserved.

The main shortcoming of this approach compared with our forthcoming ACL implementation of ConductR 1.2 is that we do not test the HTTP method.

Sample output for the chirper-impl:

```
> show bundleOverrideEndpoints

[info] Some(Map(chirpservice -> Endpoint(http,0,Some(Set(http://:9000/chirpservice, 
http://:9000/api/chirps/live?preservePath, http://:9000/api/chirps/history?preservePath)),None,None), 
akka-remote -> Endpoint(tcp,0,Some(Set()),None,None)))
```