### PR TITLE
Service endpoints without path parameter

### DIFF
--- a/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala
@@ -185,7 +185,14 @@ object LagomBundle extends AutoPlugin {
   private def toClasspathUrls(attributedFiles: Seq[Attributed[File]]): Array[URL] =
     attributedFiles.files.map(_.toURI.toURL).toArray
 
-  private val pathBeginExtractor = """^\\Q(/.*)\\E.*""".r
+  // Matches strings that starts with sequence escaping, e.g. \Q/api/users/:id\E
+  // The first sequence escaped substring that starts with a '/' is extracted as a variable
+  // Examples:
+  // /api/users                         => false
+  // \Q/api/users\E                     => true, variable = /api/users
+  // \Q/api/users/\E([^/]+)             => true, variable = /api/users/
+  // \Q/api/users/\E([^/]+)\Q/friends\E => true, variable = /api/users/
+  private val pathBeginExtractor = """^\\Q(/.+?)\\E.*""".r
 
   /**
     * Convert services string to `Map[String, Endpoint]` by using the Play json library

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/multi-services-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/multi-services-api/src/main/java/api/FooService.java
@@ -11,12 +11,16 @@ import static com.lightbend.lagom.javadsl.api.Service.*;
 
 public interface FooService extends Service {
 
+  ServiceCall<NotUsed, NotUsed, NotUsed> foos();
   ServiceCall<NotUsed, NotUsed, NotUsed> foo();
+  ServiceCall<NotUsed, NotUsed, NotUsed> fooFriends();
 
   @Override
   default Descriptor descriptor() {
     return named("/fooservice").with(
-      restCall(Method.GET,  "/foo", foo())
+      restCall(Method.GET,  "/foo", foos()),
+      restCall(Method.GET,  "/foo/:id", foo()),
+      restCall(Method.GET,  "/foo/:id/friends", fooFriends())
     ).withAutoAcl(true);
   }
 }

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/multi-services-impl/src/main/java/impl/FooServiceImpl.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/multi-services-impl/src/main/java/impl/FooServiceImpl.java
@@ -11,7 +11,21 @@ import akka.stream.javadsl.Source;
 public class FooServiceImpl implements FooService {
 
   @Override
+  public ServiceCall<NotUsed, NotUsed, NotUsed> foos() {
+    return (id, request) -> {
+      return CompletableFuture.completedFuture(NotUsed.getInstance());
+    };
+  }
+
+  @Override
   public ServiceCall<NotUsed, NotUsed, NotUsed> foo() {
+    return (id, request) -> {
+      return CompletableFuture.completedFuture(NotUsed.getInstance());
+    };
+  }
+
+  @Override
+  public ServiceCall<NotUsed, NotUsed, NotUsed> fooFriends() {
     return (id, request) -> {
       return CompletableFuture.completedFuture(NotUsed.getInstance());
     };


### PR DESCRIPTION
When collecting and converting the Lagom endpoints to ConductR endpoints we so far extract the the Lagom endpoint path as:

```
\Q/api/users\E => /api/users
\Q/api/users/\E([^/]+) => /api/users/
\Q/api/users/\E([^/]+)\Q/friends\E => /api/users/\E([^/]+)\Q/friends
```

The last one `/api/users/\E([^/]+)\Q/friends\E` will the following error during `bundle:dist`:

```
[info] java.net.URISyntaxException: Illegal character in path at index 17: http://:9000/api/users/\E([^/]+)\Q/friends?preservePath
```

In other words we've got an error for all uri path that contain a path parameter (`:id`) but do not end with the path parameter.

The regex extractor has been changed to that the extracted path now always ends before the first path parameter. The above example results into:

```
\Q/api/users\E => /api/users
\Q/api/users/\E([^/]+) => /api/users/
\Q/api/users/\E([^/]+)\Q/friends\E => /api/users/
```