### PR TITLE
Re-instated the service locator uri

### DIFF
--- a/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala
+++ b/src/main/scala/com/typesafe/sbt/bundle/LagomBundle.scala
@@ -9,6 +9,7 @@ import com.typesafe.sbt.SbtNativePackager
 import sbt._
 import sbt.Keys._
 import play.api.libs.json._
+import scala.collection.immutable.ListSet
 import scala.reflect.ClassTag
 import scala.util.{Success, Failure, Try}
 import sbt.Resolver.bintrayRepo
@@ -202,8 +203,8 @@ object LagomBundle extends AutoPlugin {
     def toEndpoint(serviceNameAndPath: (String, Seq[String])): (String, Endpoint) =
       serviceNameAndPath match {
         case (serviceName, pathBegins) =>
-          val uris = pathBegins.map(p => URI(s"http://:$servicePort$p")).toSet
-          serviceName -> Endpoint("http", services = uris)
+          val uris = pathBegins.map(p => URI(s"http://:$servicePort$p")).to[ListSet] // ListSet makes it easier to test
+          serviceName -> Endpoint("http", services = uris + URI(s"http://:$servicePort/$serviceName") )
       }
     def mergeEndpoint(endpoints: Map[String, Endpoint], endpoint: (String, Endpoint)): Map[String, Endpoint] =
       endpoint match {

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/build.sbt
@@ -28,10 +28,10 @@ checkBundleConf := {
 
   val creditContent = IO.read((target in creditImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedCreditContent = """|endpoints = {
-                                 |  "payment" = {
+                                 |  "creditservice" = {
                                  |    bind-protocol = "http"
                                  |    bind-port     = 0
-                                 |    services      = ["http://:9000/credit?preservePath"]
+                                 |    services      = ["http://:9000/creditservice", "http://:9000/credit?preservePath"]
                                  |  },
                                  |  "akka-remote" = {
                                  |    bind-protocol = "tcp"
@@ -43,10 +43,10 @@ checkBundleConf := {
 
   val debitContent = IO.read((target in debitImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedDebitContent = """|endpoints = {
-                                |  "payment" = {
+                                |  "debitservice" = {
                                 |    bind-protocol = "http"
                                 |    bind-port     = 0
-                                |    services      = ["http://:9000/debit?preservePath"]
+                                |    services      = ["http://:9000/debitservice", "http://:9000/debit?preservePath"]
                                 |  },
                                 |  "akka-remote" = {
                                 |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/credit-api/src/main/java/api/CreditService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/credit-api/src/main/java/api/CreditService.java
@@ -15,7 +15,7 @@ public interface CreditService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/payment").with(
+    return named("creditservice").with(
       restCall(Method.GET,  "/credit", credit())
     ).withAutoAcl(true);
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/debit-api/src/main/java/api/DebitService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-same-service-name/debit-api/src/main/java/api/DebitService.java
@@ -15,7 +15,7 @@ public interface DebitService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/payment").with(
+    return named("debitservice").with(
       restCall(Method.GET,  "/debit", debit())
     ).withAutoAcl(true);
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/backend-api/src/main/java/api/BackendService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/backend-api/src/main/java/api/BackendService.java
@@ -15,7 +15,7 @@ public interface BackendService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/backend").with(
+    return named("backendservice").with(
       restCall(Method.GET,  "/bar", bar())
     );
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/build.sbt
@@ -28,10 +28,10 @@ checkBundleConf := {
 
   val frontendContent = IO.read((target in frontendImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedFrontendContent = """|endpoints = {
-                                   |  "frontend" = {
+                                   |  "frontendservice" = {
                                    |    bind-protocol = "http"
                                    |    bind-port     = 0
-                                   |    services      = ["http://:9000/foo?preservePath"]
+                                   |    services      = ["http://:9000/frontendservice", "http://:9000/foo?preservePath"]
                                    |  },
                                    |  "akka-remote" = {
                                    |    bind-protocol = "tcp"
@@ -44,10 +44,10 @@ checkBundleConf := {
   // Acls are not enabled for the backend. As a result the service is still written to the bundle.conf
   val backendContent = IO.read((target in backendImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedBackendContent = """|endpoints = {
-                                  |  "backend" = {
+                                  |  "backendservice" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = []
+                                  |    services      = ["http://:9000/backendservice"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/frontend-api/src/main/java/api/FrontendService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects-single-acl/frontend-api/src/main/java/api/FrontendService.java
@@ -15,7 +15,7 @@ public interface FrontendService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/frontend").with(
+    return named("frontendservice").with(
       restCall(Method.GET,  "/foo", foo())
     ).withAutoAcl(true);
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects/build.sbt
@@ -28,15 +28,15 @@ checkBundleConf := {
 
   val paymentContent = IO.read((target in paymentImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedPaymentContent = """|endpoints = {
-                                  |  "debit" = {
+                                  |  "debitservice" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000?preservePath"]
+                                  |    services      = ["http://:9000/debitservice", "http://:9000?preservePath"]
                                   |  },
-                                  |  "credit" = {
+                                  |  "creditservice" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000?preservePath"]
+                                  |    services      = ["http://:9000/creditservice", "http://:9000?preservePath"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"
@@ -48,10 +48,10 @@ checkBundleConf := {
 
   val socialContent = IO.read((target in socialImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
   val expectedSocialContent = """|endpoints = {
-                                 |  "social/feed" = {
+                                 |  "socialservice" = {
                                  |    bind-protocol = "http"
                                  |    bind-port     = 0
-                                 |    services      = ["http://:9000?preservePath"]
+                                 |    services      = ["http://:9000/socialservice", "http://:9000?preservePath"]
                                  |  },
                                  |  "akka-remote" = {
                                  |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects/payment-api/src/main/java/api/CreditService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects/payment-api/src/main/java/api/CreditService.java
@@ -15,7 +15,7 @@ public interface CreditService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/credit").with(
+    return named("/creditservice").with(
       restCall(Method.GET,  "/", credit())
     ).withAutoAcl(true);
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects/payment-api/src/main/java/api/DebitService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects/payment-api/src/main/java/api/DebitService.java
@@ -15,7 +15,7 @@ public interface DebitService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/debit").with(
+    return named("/debitservice").with(
       restCall(Method.GET,  "/", debit())
     ).withAutoAcl(true);
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-projects/social-api/src/main/java/api/FeedService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-projects/social-api/src/main/java/api/FeedService.java
@@ -15,7 +15,7 @@ public interface FeedService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/social/feed").with(
+    return named("/socialservice").with(
       restCall(Method.GET,  "/", feed())
     ).withAutoAcl(true);
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/build.sbt
@@ -20,11 +20,11 @@ checkBundleConf := {
   }
 
   val paymentContent = IO.read((target in paymentImpl in Bundle).value / "bundle" / "tmp" / "bundle.conf").indent
-  val expectedPaymentContent1 = """|endpoints = {
-                                  |  "payment" = {
+  val expectedPaymentContent = """|endpoints = {
+                                  |  "paymentservice" = {
                                   |    bind-protocol = "http"
                                   |    bind-port     = 0
-                                  |    services      = ["http://:9000/debit?preservePath", "http://:9000/credit?preservePath"]
+                                  |    services      = ["http://:9000/credit?preservePath", "http://:9000/paymentservice", "http://:9000/debit?preservePath"]
                                   |  },
                                   |  "akka-remote" = {
                                   |    bind-protocol = "tcp"
@@ -32,17 +32,5 @@ checkBundleConf := {
                                   |    services= []
                                   |  }
                                   |}""".stripMargin.indent
-  val expectedPaymentContent2 = """|endpoints = {
-                                  |  "payment" = {
-                                  |    bind-protocol = "http"
-                                  |    bind-port     = 0
-                                  |    services      = ["http://:9000/credit?preservePath", "http://:9000/debit?preservePath"]
-                                  |  },
-                                  |  "akka-remote" = {
-                                  |    bind-protocol = "tcp"
-                                  |    bind-port = 0
-                                  |    services= []
-                                  |  }
-                                  |}""".stripMargin.indent
-  paymentContent should (include (expectedPaymentContent1) or include (expectedPaymentContent2))
+  paymentContent should include (expectedPaymentContent)
 }

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/payment-api/src/main/java/api/CreditService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/payment-api/src/main/java/api/CreditService.java
@@ -15,7 +15,7 @@ public interface CreditService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/payment").with(
+    return named("paymentservice").with(
       restCall(Method.GET,  "/credit", credit())
     ).withAutoAcl(true);
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/payment-api/src/main/java/api/DebitService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project-same-service-name/payment-api/src/main/java/api/DebitService.java
@@ -15,7 +15,7 @@ public interface DebitService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/payment").with(
+    return named("paymentservice").with(
       restCall(Method.GET,  "/debit", debit())
     ).withAutoAcl(true);
   }

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/build.sbt
@@ -24,12 +24,12 @@ checkBundleConf := {
                            |  "fooservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/foo?preservePath"]
+                           |    services      = ["http://:9000/fooservice", "http://:9000/foo?preservePath"]
                            |  },
                            |  "barservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/bar?preservePath"]
+                           |    services      = ["http://:9000/barservice", "http://:9000/bar?preservePath"]
                            |  },
                            |  "akka-remote" = {
                            |    bind-protocol = "tcp"

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/multi-services-api/src/main/java/api/BarService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/multi-services-api/src/main/java/api/BarService.java
@@ -16,7 +16,7 @@ public interface BarService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/barservice").with(
+    return named("barservice").with(
       restCall(Method.GET,  "/bar", getBar()),
       restCall(Method.POST, "/bar", addBar())
     ).withAutoAcl(true);

--- a/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/multi-services-api/src/main/java/api/FooService.java
+++ b/src/sbt-test/sbt-lagom-bundle/multi-services-one-project/multi-services-api/src/main/java/api/FooService.java
@@ -17,7 +17,7 @@ public interface FooService extends Service {
 
   @Override
   default Descriptor descriptor() {
-    return named("/fooservice").with(
+    return named("fooservice").with(
       restCall(Method.GET,  "/foo", foos()),
       restCall(Method.GET,  "/foo/:id", foo()),
       restCall(Method.GET,  "/foo/:id/friends", fooFriends())

--- a/src/sbt-test/sbt-lagom-bundle/simple/build.sbt
+++ b/src/sbt-test/sbt-lagom-bundle/simple/build.sbt
@@ -23,7 +23,7 @@ checkBundleConf := {
                            |  "fooservice" = {
                            |    bind-protocol = "http"
                            |    bind-port     = 0
-                           |    services      = ["http://:9000/foo?preservePath"]
+                           |    services      = ["http://:9000/fooservice", "http://:9000/foo?preservePath"]
                            |  },
                            |  "akka-remote" = {
                            |    bind-protocol = "tcp"


### PR DESCRIPTION
I'd forgotten that we had to provide a URI just for the purposes of registering with the service locator - not just for proxying. Bring on our 1.2 ACL activities which clears this area up. :-)

I also cleared up some tests so that service names are generally distinct from their ACL paths. It wouldn't hurt if they are not so distinct in generally (ConductR sorts them by most distinct first). However there were one or two places where in fact they were distinct from a test perspective.

These changes finally allow Chirper to work within ConductR.